### PR TITLE
Bumping jacoc version to 0.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <testng.version>6.11</testng.version>
         <mongodb.driver.version>3.4.2</mongodb.driver.version>
         <fabric8.docker.version>0.21.0</fabric8.docker.version>
-        <jacoco.plugin.version>0.7.8</jacoco.plugin.version>
-        <jacoco.ant.version>0.7.8</jacoco.ant.version>
+        <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
+        <jacoco.ant.version>0.7.9</jacoco.ant.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Purpose
Standardizing the version of Jacoco plugin used

## Approach
Bumped Jacoco version to 0.7.9

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes