### PR TITLE
Add support for multiple @Index annotations to define multiple indexes

### DIFF
--- a/component/src/main/java/io/siddhi/extension/store/mongodb/MongoDBEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/mongodb/MongoDBEventTable.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static io.siddhi.core.util.SiddhiConstants.ANNOTATION_INDEX;
 import static io.siddhi.core.util.SiddhiConstants.ANNOTATION_INDEX_BY;
 import static io.siddhi.core.util.SiddhiConstants.ANNOTATION_PRIMARY_KEY;
 import static io.siddhi.core.util.SiddhiConstants.ANNOTATION_STORE;
@@ -294,8 +295,6 @@ public class MongoDBEventTable extends AbstractRecordTable {
                 .getAnnotation(ANNOTATION_STORE, tableDefinition.getAnnotations());
         Annotation primaryKeys = AnnotationHelper
                 .getAnnotation(ANNOTATION_PRIMARY_KEY, tableDefinition.getAnnotations());
-        List<Annotation> indices = AnnotationHelper
-                .getAnnotations(ANNOTATION_INDEX_BY, tableDefinition.getAnnotations());
 
         this.initializeConnectionParameters(storeAnnotation, configReader);
 
@@ -310,8 +309,18 @@ public class MongoDBEventTable extends AbstractRecordTable {
         if (primaryKey != null) {
             this.expectedIndexModels.add(primaryKey);
         }
-        this.expectedIndexModels.addAll(MongoTableUtils.extractIndexModels(indices, this.attributeNames,
-                this.collectionName));
+
+        List<Annotation> indices = AnnotationHelper
+                .getAnnotations(ANNOTATION_INDEX, tableDefinition.getAnnotations());
+        if (!indices.isEmpty()) {
+            this.expectedIndexModels.addAll(MongoTableUtils.extractIndexModels(indices, this.attributeNames,
+                    this.collectionName));
+        } else {
+            Annotation indexBy = AnnotationHelper
+                    .getAnnotation(ANNOTATION_INDEX_BY, tableDefinition.getAnnotations());
+            this.expectedIndexModels.addAll(MongoTableUtils.extractIndexModels(indexBy, this.attributeNames,
+                    this.collectionName));
+        }
     }
 
     /**

--- a/component/src/main/java/io/siddhi/extension/store/mongodb/MongoDBEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/mongodb/MongoDBEventTable.java
@@ -253,25 +253,30 @@ import static io.siddhi.core.util.SiddhiConstants.ANNOTATION_STORE;
                         syntax = "@Store(type=\"mongodb\"," +
                                 "mongodb.uri=\"mongodb://admin:admin@localhost/Foo\")\n" +
                                 "@PrimaryKey(\"symbol\")\n" +
-                                "@IndexBy(\"volume 1 {background:true,unique:true}\")\n" +
+                                "@Index(\"volume:1\", {background:true,unique:true}\")\n" +
                                 "define table FooTable (symbol string, price float, volume long);",
                         description = "This will create a collection called FooTable for the events to be saved " +
-                                "with symbol as Primary Key(unique index at mongod level) and index for the field " +
+                                "with symbol as Primary Key(unique index at mongoDB level) and index for the field " +
                                 "volume will be created in ascending order with the index option to create the index " +
                                 "in the background.\n\n" +
                                 "Note: \n" +
                                 "@PrimaryKey: This specifies a list of comma-separated values to be treated as " +
                                 "unique fields in the table. Each record in the table must have a unique combination " +
                                 "of values for the fields specified here.\n\n" +
-                                "@IndexBy: This specifies the fields that must be indexed at the database level. " +
+                                "@Index: This specifies the fields that must be indexed at the database level. " +
                                 "You can specify multiple values as a come-separated list. A single value to be in " +
-                                "the format,\n“<FieldName> <SortOrder> <IndexOptions>”\n" +
-                                "<SortOrder> - ( 1) for Ascending and (-1) for Descending\n" +
-                                "<IndexOptions> - Index Options must be defined inside curly brackets. {} to be " +
-                                "used for default options. Options must follow the standard mongodb index options " +
-                                "format. Reference : " +
-                                "https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/\n" +
-                                "Example : “symbol 1 {“unique”:true}”\n"
+                                "the format,\n`<FieldName>:<SortOrder>`. The last element is optional through which " +
+                                "a valid index options can be passed.\n" +
+                                "\t\t<SortOrder> : 1 for Ascending & -1 for Descending. " +
+                                "Optional, with default value as 1.\n" +
+                                "\t\t<IndexOptions> : Index Options must be defined inside curly brackets.\n" +
+                                "\t\t\tOptions must follow the standard mongodb index options format.\n" +
+                                "\t\t\thttps://docs.mongodb.com/manual/reference/method/db.collection.createIndex/" +
+                                "\n\n" +
+                                "Example 1: @Index(`'symbol:1'`, `'{\"unique\":true}'`)\n" +
+                                "Example 2: @Index(`'symbol'`, `'{\"unique\":true}'`)\n" +
+                                "Example 3: @Index(`'symbol:1'`, `'volume:-1'`, `'{\"unique\":true}'`)\n"
+
                 )
         }
 )

--- a/component/src/main/java/io/siddhi/extension/store/mongodb/MongoDBEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/mongodb/MongoDBEventTable.java
@@ -294,23 +294,24 @@ public class MongoDBEventTable extends AbstractRecordTable {
                 .getAnnotation(ANNOTATION_STORE, tableDefinition.getAnnotations());
         Annotation primaryKeys = AnnotationHelper
                 .getAnnotation(ANNOTATION_PRIMARY_KEY, tableDefinition.getAnnotations());
-        Annotation indices = AnnotationHelper
-                .getAnnotation(ANNOTATION_INDEX_BY, tableDefinition.getAnnotations());
+        List<Annotation> indices = AnnotationHelper
+                .getAnnotations(ANNOTATION_INDEX_BY, tableDefinition.getAnnotations());
 
         this.initializeConnectionParameters(storeAnnotation, configReader);
-
-        this.expectedIndexModels = new ArrayList<>();
-        IndexModel primaryKey = MongoTableUtils.extractPrimaryKey(primaryKeys, this.attributeNames);
-        if (primaryKey != null) {
-            this.expectedIndexModels.add(primaryKey);
-        }
-        this.expectedIndexModels.addAll(MongoTableUtils.extractIndexModels(indices, this.attributeNames));
 
         String customCollectionName = storeAnnotation.getElement(
                 MongoTableConstants.ANNOTATION_ELEMENT_COLLECTION_NAME);
         this.collectionName = MongoTableUtils.isEmpty(customCollectionName) ?
                 tableDefinition.getId() : customCollectionName;
         this.initialCollectionTest = false;
+
+        this.expectedIndexModels = new ArrayList<>();
+        IndexModel primaryKey = MongoTableUtils.extractPrimaryKey(primaryKeys, this.attributeNames);
+        if (primaryKey != null) {
+            this.expectedIndexModels.add(primaryKey);
+        }
+        this.expectedIndexModels.addAll(MongoTableUtils.extractIndexModels(indices, this.attributeNames,
+                this.collectionName));
     }
 
     /**

--- a/component/src/main/java/io/siddhi/extension/store/mongodb/util/MongoTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/mongodb/util/MongoTableConstants.java
@@ -45,6 +45,8 @@ public class MongoTableConstants {
     public static final String REG_SIMPLE_EXPRESSION = "^\\{(\\S*):\\{.*}}$";
     public static final String REG_STREAMVAR_OR_CONST = "^strVar\\d*|^const\\d*";
     public static final String REG_INDEX_BY = "^(\\S*)(\\s1|\\s-1)?(\\s\\{.*})?$";
+    public static final String REG_INDEX_BY_NEW_ATTRIBUTE = "^(\\S+):(1|-1)$";
+    public static final String REG_INDEX_BY_NEW_OPTIONS = "^{.*}$";
 
     //Mongo filters for condition builder
     public static final String MONGO_AND_FILTER = "{$and:[{{LEFT_OPERAND}},{{RIGHT_OPERAND}}]}";

--- a/component/src/main/java/io/siddhi/extension/store/mongodb/util/MongoTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/mongodb/util/MongoTableConstants.java
@@ -45,8 +45,7 @@ public class MongoTableConstants {
     public static final String REG_SIMPLE_EXPRESSION = "^\\{(\\S*):\\{.*}}$";
     public static final String REG_STREAMVAR_OR_CONST = "^strVar\\d*|^const\\d*";
     public static final String REG_INDEX_BY = "^(\\S*)(\\s1|\\s-1)?(\\s\\{.*})?$";
-    public static final String REG_INDEX_BY_NEW_ATTRIBUTE = "^(\\S+):(1|-1)$";
-    public static final String REG_INDEX_BY_NEW_OPTIONS = "^{.*}$";
+    public static final String REG_INDEX_BY_NEW_OPTIONS = "^\\{.*\\}$";
 
     //Mongo filters for condition builder
     public static final String MONGO_AND_FILTER = "{$and:[{{LEFT_OPERAND}},{{RIGHT_OPERAND}}]}";

--- a/component/src/test/java/io/siddhi/extension/store/mongodb/DefineMongoTableTest.java
+++ b/component/src/test/java/io/siddhi/extension/store/mongodb/DefineMongoTableTest.java
@@ -559,4 +559,286 @@ public class DefineMongoTableTest {
         Assert.assertEquals(indexActual, indexExcepted, "Primary Key Definition Failed");
     }
 
+    @Test
+    public void mongoTableDefinitionTest25() {
+        log.info("mongoTableDefinitionTest25 - " +
+                "DASC5-868:Defining a MongoDB event table with Index field");
+
+        MongoTableTestUtils.dropCollection(uri, "FooTable");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', " +
+                "mongodb.uri='" + uri + "')" +
+                "@Index(\"price:1\", \"{background:true}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+
+        boolean doesCollectionExists = MongoTableTestUtils.doesCollectionExists(uri, "FooTable");
+        Assert.assertEquals(doesCollectionExists, true, "Definition failed");
+
+        Document priceIndexExpected = new Document()
+                .append("name", "price_1")
+                .append("v", 2)
+                .append("key", new Document("price", 1))
+                .append("background", true);
+        Document priceIndexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "price_1");
+        Assert.assertEquals(priceIndexActual, priceIndexExpected, "Index Creation Failed");
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class)
+    public void mongoTableDefinitionTest26() {
+        log.info("mongoTableDefinitionTest26 - " +
+                "DASC5-869:Defining a MongoDB table without defining a value for indexing column within Index field");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', " +
+                "mongodb.uri='" + uri + "')" +
+                "@Index(\"1 {background:true}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class)
+    public void mongoTableDefinitionTest27() {
+        log.info("mongoTableDefinitionTest27 - " +
+                "DASC5-870:Defining a MongoDB table with an invalid value for indexing column within IndexBy field");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"symbol1234:1\", \"{unique:true}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void mongoTableDefinitionTest28() {
+        log.info("mongoTableDefinitionTest28 - " +
+                "DASC5-872:Defining a MongoDB table without defining a value for sorting within Index field");
+
+        MongoTableTestUtils.dropCollection(uri, "FooTable");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"symbol\", \"{unique:true}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+
+        boolean doesCollectionExists = MongoTableTestUtils.doesCollectionExists(uri, "FooTable");
+        Assert.assertEquals(doesCollectionExists, true, "Definition failed");
+
+        Document indexExcepted = new org.bson.Document()
+                .append("key", new org.bson.Document("symbol", 1))
+                .append("name", "symbol_1")
+                .append("v", 2)
+                .append("unique", true);
+        Document indexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "symbol_1");
+        Assert.assertEquals(indexActual, indexExcepted, "Index Definition Failed");
+    }
+
+    @Test
+    public void mongoTableDefinitionTest29() {
+        log.info("mongoTableDefinitionTest29 - " +
+                "DASC5-872:Defining a MongoDB table without defining a value for sorting within Index field");
+
+        MongoTableTestUtils.dropCollection(uri, "FooTable");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"symbol:1\", \"{}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+
+        boolean doesCollectionExists = MongoTableTestUtils.doesCollectionExists(uri, "FooTable");
+        Assert.assertEquals(doesCollectionExists, true, "Definition failed");
+
+        Document indexExcepted = new org.bson.Document()
+                .append("key", new org.bson.Document("symbol", 1))
+                .append("name", "symbol_1")
+                .append("v", 2);
+        Document indexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "symbol_1");
+        Assert.assertEquals(indexActual, indexExcepted, "Index Definition Failed");
+    }
+
+    @Test
+    public void mongoTableDefinitionTest30() {
+        log.info("mongoTableDefinitionTest30 - " +
+                "DASC5-872:Defining a MongoDB table without defining a value for sorting within Index field");
+
+        MongoTableTestUtils.dropCollection(uri, "FooTable");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"symbol:1\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+
+        boolean doesCollectionExists = MongoTableTestUtils.doesCollectionExists(uri, "FooTable");
+        Assert.assertEquals(doesCollectionExists, true, "Definition failed");
+
+        Document indexExcepted = new org.bson.Document()
+                .append("key", new org.bson.Document("symbol", 1))
+                .append("name", "symbol_1")
+                .append("v", 2);
+        Document indexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "symbol_1");
+        Assert.assertEquals(indexActual, indexExcepted, "Index Definition Failed");
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class)
+    public void mongoTableDefinitionTest31() {
+        log.info("mongoTableDefinitionTest31 - " +
+                "DASC5-874:Defining a MongoDB table by defining non existing options within IndexBy field");
+
+        MongoTableTestUtils.dropCollection(uri, "FooTable");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"symbol:1\", \"{2222unique:true}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+
+        boolean doesCollectionExists = MongoTableTestUtils.doesCollectionExists(uri, "FooTable");
+        Assert.assertEquals(doesCollectionExists, true, "Definition failed");
+
+        Document indexExcepted = new org.bson.Document()
+                .append("key", new org.bson.Document("symbol", 1))
+                .append("name", "symbol_1")
+                .append("v", 2);
+        Document indexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "symbol_1");
+        Assert.assertEquals(indexActual, indexExcepted, "Index Definition Failed");
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class)
+    public void mongoTableDefinitionTest32() {
+        log.info("mongoTableDefinitionTest30 - " +
+                "DASC5-875:Defining a MongoDB table by defining an option with an invalid value within Index field");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"symbol:1\", \"{background:tr22ue}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void mongoTableDefinitionTest33() {
+        log.info("mongoTableDefinitionTest33 - " +
+                "DASC5-876:Defining a MongoDB table by having contradictory values for an option " +
+                "defined within Index field");
+
+        MongoTableTestUtils.dropCollection(uri, "FooTable");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"symbol:1\", \"{unique:true, unique: false}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+
+        boolean doesCollectionExists = MongoTableTestUtils.doesCollectionExists(uri, "FooTable");
+        Assert.assertEquals(doesCollectionExists, true, "Definition failed");
+
+        Document indexExcepted = new org.bson.Document()
+                .append("key", new org.bson.Document("symbol", 1))
+                .append("name", "symbol_1")
+                .append("v", 2);
+        Document indexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "symbol_1");
+        Assert.assertEquals(indexActual, indexExcepted, "Index Definition Failed");
+    }
+
+
+    @Test
+    public void mongoTableDefinitionTest34() {
+        log.info("mongoTableDefinitionTest34 - " +
+                "DASC5-965:Defining a MongoDB event table by having multiple indexing columns");
+
+        MongoTableTestUtils.dropCollection(uri, "FooTable");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"price:1\", \"{background:true}\")" +
+                "@Index(\"volume:1\", \"{background:true}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+
+        boolean doesCollectionExists = MongoTableTestUtils.doesCollectionExists(uri, "FooTable");
+        Assert.assertEquals(doesCollectionExists, true, "Definition failed");
+
+        Document priceIndexExpected = new Document()
+                .append("name", "price_1")
+                .append("v", 2)
+                .append("key", new Document("price", 1))
+                .append("background", true);
+        Document priceIndexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "price_1");
+        Assert.assertEquals(priceIndexActual, priceIndexExpected, "Index Creation Failed");
+
+        Document volumeIndexExpected = new Document()
+                .append("name", "volume_1")
+                .append("v", 2)
+                .append("key", new Document("volume", 1))
+                .append("background", true);
+        Document volumeIndexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "volume_1");
+        Assert.assertEquals(volumeIndexActual, volumeIndexExpected, "Index Creation Failed");
+    }
+
+    @Test
+    public void mongoTableDefinitionTest35() {
+        log.info("mongoTableDefinitionTest35 - " +
+                "DASC5-965:Defining a MongoDB event table by having compound indexing columns");
+
+        MongoTableTestUtils.dropCollection(uri, "FooTable");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@store(type = 'mongodb', mongodb.uri='" + uri + "')" +
+                "@Index(\"price:1\", \"volume:1\", \"{background:true}\")" +
+                "define table FooTable (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+        siddhiAppRuntime.shutdown();
+
+        boolean doesCollectionExists = MongoTableTestUtils.doesCollectionExists(uri, "FooTable");
+        Assert.assertTrue(doesCollectionExists, "Definition failed");
+
+        Document indexFields = new Document("price", 1);
+        indexFields.put("volume", 1);
+
+        Document compoundIndexExpected = new Document()
+                .append("name", "volume_1_price_1")
+                .append("v", 2)
+                .append("key", indexFields)
+                .append("background", true);
+        Document compoundIndexActual = MongoTableTestUtils.getIndex(uri, "FooTable", "volume_1_price_1");
+        Assert.assertEquals(compoundIndexActual, compoundIndexExpected, "Index Creation Failed");
+
+    }
+
 }


### PR DESCRIPTION
## Purpose
$subject as part of https://github.com/siddhi-io/siddhi/issues/1228

## Approach
Define multiple indexes when creating MongoDB collections

## Release note
Add support to define multiple indexes

## Automation tests
 - Unit tests - Attached herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK1.8.0_191, MongoDB 3.4