### PR TITLE
Fix Mongodb join to correctly work when Object_ID is passed

### DIFF
--- a/component/src/main/java/io/siddhi/extension/store/mongodb/MongoExpressionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/mongodb/MongoExpressionVisitor.java
@@ -197,11 +197,17 @@ public class MongoExpressionVisitor extends BaseExpressionVisitor {
 
     @Override
     public void endVisitCompare(Compare.Operator operator) {
-        String compareFilter = MongoTableConstants.MONGO_COMPARE_FILTER;
-        String compareOperator = MongoTableUtils.getCompareOperator(operator);
-        compareFilter = compareFilter.replace(MongoTableConstants.PLACEHOLDER_COMPARE_OPERATOR, compareOperator);
         String rightOperand = this.conditionOperands.pop();
         String leftOperand = this.conditionOperands.pop();
+        String compareFilter;
+        if (rightOperand.equals(MongoTableConstants.MONGO_OBJECT_ID)) {
+            compareFilter = MongoTableConstants.MONGO_COMPARE_FILTER_FOR_OBJECT_ID;
+        } else {
+            compareFilter = MongoTableConstants.MONGO_COMPARE_FILTER;
+        }
+        String compareOperator = MongoTableUtils.getCompareOperator(operator);
+        compareFilter = compareFilter.replace(MongoTableConstants.PLACEHOLDER_COMPARE_OPERATOR, compareOperator);
+
         if (!rightOperand.matches(MongoTableConstants.REG_EXPRESSION) &&
                 !leftOperand.matches(MongoTableConstants.REG_EXPRESSION)) {
             if (leftOperand.matches(MongoTableConstants.REG_STREAMVAR_OR_CONST) !=

--- a/component/src/main/java/io/siddhi/extension/store/mongodb/util/MongoTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/mongodb/util/MongoTableConstants.java
@@ -40,6 +40,8 @@ public class MongoTableConstants {
     public static final String MONGO_COMPARE_NOT_EQUAL = "$ne";
     public static final String MONGO_NOT = "$not";
 
+    public static final String MONGO_OBJECT_ID = "_id";
+
     //Regex for comparing operands
     public static final String REG_EXPRESSION = "\\{.*}$";
     public static final String REG_SIMPLE_EXPRESSION = "^\\{(\\S*):\\{.*}}$";
@@ -52,6 +54,8 @@ public class MongoTableConstants {
     public static final String MONGO_OR_FILTER = "{$or:[{{LEFT_OPERAND}},{{RIGHT_OPERAND}}]}";
     public static final String MONGO_NOT_FILTER = "{{{FIELD_NAME}}:{{OPERAND}}}";
     public static final String MONGO_COMPARE_FILTER = "{{{LEFT_OPERAND}}:{{{COMPARE_OPERATOR}}:{{RIGHT_OPERAND}}}}";
+    public static final String MONGO_COMPARE_FILTER_FOR_OBJECT_ID = "{{{LEFT_OPERAND}}:{{{COMPARE_OPERATOR}}:" +
+            "{$oid:{{RIGHT_OPERAND}}}}}";
     public static final String MONGO_IS_NULL_FILTER = "{{{OPERAND}}:{$eq:null}}";
 
     //Mongo filters for math operators


### PR DESCRIPTION
## Purpose
Fix mongo db join to correctly work with document ID when passed to find a specific record

## Goals
Improve the join/find  function

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
