### PR TITLE
Change mongodb version range for osgi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
         <testng.version>6.11</testng.version>
         <mongodb.driver.sync.version>4.9.1</mongodb.driver.sync.version>
         <mongodb.driver.core.version>4.9.1</mongodb.driver.core.version>
-        <mongodb.driver.version.range>[4.9.1,5.2.1)</mongodb.driver.version.range>
-        <bson.version.range>[4.9.1,5.2.1)</bson.version.range>
+        <mongodb.driver.version.range>[0,6)</mongodb.driver.version.range>
+        <bson.version.range>[0,6)</bson.version.range>
         <fabric8.docker.version>0.21.0</fabric8.docker.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <jacoco.ant.version>0.7.9</jacoco.ant.version>


### PR DESCRIPTION
$subject.
This driver is a jar and is converted to an osgi bundle by the SI thus changing its version range. So the import version range is also changed